### PR TITLE
Move `readFile` logic to `tools.ts`

### DIFF
--- a/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
@@ -2,6 +2,7 @@
 
 import { GeoJSONFeature1, IJupyterGISModel } from '@jupytergis/schema';
 import { useEffect, useState } from 'react';
+import { readFile } from '../../../tools';
 
 interface IUseGetPropertiesProps {
   layerId?: string;
@@ -35,7 +36,7 @@ export const useGetProperties = ({
         throw new Error('Source not found');
       }
 
-      const data = await model.readFile(
+      const data = await readFile(
         source.parameters?.path,
         'GeoJSONSource'
       );

--- a/packages/base/src/formbuilder/objectform/geojsonsource.ts
+++ b/packages/base/src/formbuilder/objectform/geojsonsource.ts
@@ -3,6 +3,7 @@ import { showErrorMessage } from '@jupyterlab/apputils';
 import { ISubmitEvent } from '@rjsf/core';
 import { Ajv, ValidateFunction } from 'ajv';
 import * as geojson from '@jupytergis/schema/src/schema/geojson.json';
+import { readFile } from '../../tools';
 
 import { BaseForm, IBaseFormProps } from './baseform';
 
@@ -67,7 +68,7 @@ export class GeoJSONSourcePropertiesForm extends BaseForm {
     let valid = false;
     if (path) {
       try {
-        const geoJSONData = await this.props.model.readFile(
+        const geoJSONData = await readFile(
           path,
           'GeoJSONSource'
         );

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -60,7 +60,7 @@ import { Rule } from 'ol/style/flat';
 import proj4 from 'proj4';
 import * as React from 'react';
 import shp from 'shpjs';
-import { isLightTheme, loadGeoTIFFWithCache, throttle } from '../tools';
+import { isLightTheme, loadGeoTIFFWithCache, throttle, readFile } from '../tools';
 import { MainViewModel } from './mainviewmodel';
 import { Spinner } from './spinner';
 //@ts-expect-error no types for proj4-list
@@ -425,7 +425,7 @@ export class MainView extends React.Component<IProps, IStates> {
       case 'GeoJSONSource': {
         const data =
           source.parameters?.data ||
-          (await this._model.readFile(
+          (await readFile(
             source.parameters?.path,
             'GeoJSONSource'
           ));
@@ -459,7 +459,7 @@ export class MainView extends React.Component<IProps, IStates> {
           geojson = await this._loadShapefileAsGeoJSON(parameters.path);
         } else {
           // Handle local files using the model's readFile method
-          geojson = await this._model.readFile(
+          geojson = readFile(
             parameters.path,
             'ShapefileSource'
           );
@@ -515,7 +515,7 @@ export class MainView extends React.Component<IProps, IStates> {
         ) {
           imageUrl = sourceParameters.url;
         } else {
-          imageUrl = await this._model.readFile(
+          imageUrl = await readFile(
             sourceParameters.url,
             'ImageSource'
           );

--- a/packages/base/src/panelview/components/filter-panel/Filter.tsx
+++ b/packages/base/src/panelview/components/filter-panel/Filter.tsx
@@ -13,6 +13,7 @@ import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { debounce, getLayerTileInfo } from '../../../tools';
 import { IControlPanelModel } from '../../../types';
 import FilterRow from './FilterRow';
+import { readFile } from '../../../tools';
 
 /**
  * The filters panel widget.
@@ -209,7 +210,7 @@ const FilterComponent = (props: IFilterComponentProps) => {
         break;
       }
       case 'GeoJSONSource': {
-        const data = await model?.readFile(
+        const data = await readFile(
           source.parameters?.path,
           'GeoJSONSource'
         );

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -8,7 +8,7 @@ import {
 import { IWidgetTracker } from '@jupyterlab/apputils';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
-import { Contents, User } from '@jupyterlab/services';
+import { User } from '@jupyterlab/services';
 import { ISignal, Signal } from '@lumino/signaling';
 import { SplitPanel } from '@lumino/widgets';
 
@@ -163,10 +163,6 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   sharedMetadataChanged: ISignal<IJupyterGISModel, MapChange>;
   zoomToAnnotationSignal: ISignal<IJupyterGISModel, string>;
 
-  setContentsManager(
-    value: Contents.IManager | undefined,
-    filePath: string
-  ): void;
   getContent(): IJGISContent;
   getLayers(): IJGISLayers;
   getLayer(id: string): IJGISLayer | undefined;
@@ -184,8 +180,6 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   removeLayer(id: string): void;
   getOptions(): IJGISOptions;
   setOptions(value: IJGISOptions): void;
-
-  readFile(filepath: string, type: SourceType): Promise<any | undefined>;
 
   removeLayerGroup(groupName: string): void;
   renameLayerGroup(groupName: string, newName: string): void;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -1,12 +1,10 @@
 import { MapChange } from '@jupyter/ydoc';
-import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
+import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { PartialJSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import Ajv from 'ajv';
 
-import shp from 'shpjs';
-// import GeoTIFF from 'geotiff';
 import {
   IJGISContent,
   IJGISLayer,
@@ -33,7 +31,6 @@ import {
   IUserData
 } from './interfaces';
 import jgisSchema from './schema/jgis.json';
-import { Contents } from '@jupyterlab/services';
 
 export class JupyterGISModel implements IJupyterGISModel {
   constructor(options: JupyterGISModel.IOptions) {
@@ -246,14 +243,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     };
   }
 
-  setContentsManager(
-    value: Contents.IManager | undefined,
-    filePath: string
-  ): void {
-    this._contentsManager = value;
-    this._filePath = filePath;
-  }
-
   getLayers(): IJGISLayers {
     return this.sharedModel.layers;
   }
@@ -303,112 +292,6 @@ export class JupyterGISModel implements IJupyterGISModel {
       }
     });
     return usingLayers;
-  }
-
-  /**
-   * Generalized file reader for different source types.
-   *
-   * @param filepath - Path to the file.
-   * @param type - Type of the source file (e.g., "GeoJSONSource", "ShapefileSource").
-   * @returns A promise that resolves to the file content.
-   */
-  async readFile(
-    filepath: string,
-    type: IJGISSource['type']
-  ): Promise<any | undefined> {
-    if (!this._contentsManager) {
-      throw new Error('ContentsManager is not initialized.');
-    }
-
-    const absolutePath = PathExt.resolve(
-      PathExt.dirname(this._filePath),
-      filepath
-    );
-
-    try {
-      const file = await this._contentsManager.get(absolutePath, {
-        content: true
-      });
-
-      if (!file.content) {
-        throw new Error(`File at ${absolutePath} is empty or inaccessible.`);
-      }
-
-      switch (type) {
-        case 'GeoJSONSource': {
-          if (typeof file.content === 'string') {
-            return JSON.parse(file.content);
-          }
-          return file.content;
-        }
-
-        case 'ShapefileSource': {
-          const arrayBuffer = await this._stringToArrayBuffer(
-            file.content as string
-          );
-          const geojson = await shp(arrayBuffer);
-          return geojson;
-        }
-
-        case 'ImageSource': {
-          if (typeof file.content === 'string') {
-            // Convert base64 to a data URL
-            const mimeType = this._getMimeType(filepath);
-            return `data:${mimeType};base64,${file.content}`;
-          } else {
-            throw new Error('Invalid file format for image content');
-          }
-        }
-
-        default: {
-          throw new Error(`Unsupported source type: ${type}`);
-        }
-      }
-    } catch (error) {
-      console.error(`Error reading file '${filepath}':`, error);
-      throw error;
-    }
-  }
-
-  /**
-   * Determine the MIME type based on the file extension.
-   *
-   * @param filename - The name of the file.
-   * @returns A string representing the MIME type.
-   */
-  private _getMimeType(filename: string): string {
-    const extension = filename.split('.').pop()?.toLowerCase();
-
-    switch (extension) {
-      case 'png':
-        return 'image/png';
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'gif':
-        return 'image/gif';
-      case 'webp':
-        return 'image/webp';
-      case 'svg':
-        return 'image/svg+xml';
-      default:
-        console.warn(
-          `Unknown file extension: ${extension}, defaulting to 'application/octet-stream'`
-        );
-        return 'application/octet-stream';
-    }
-  }
-
-  /**
-   * Helper to convert a string (base64) to ArrayBuffer.
-   * @param content - File content as a base64 string.
-   * @returns An ArrayBuffer.
-   */
-  private async _stringToArrayBuffer(content: string): Promise<ArrayBuffer> {
-    const base64Response = await fetch(
-      `data:application/octet-stream;base64,${content}`
-    );
-    return await base64Response.arrayBuffer();
   }
 
   /**
@@ -745,8 +628,6 @@ export class JupyterGISModel implements IJupyterGISModel {
   readonly annotationModel?: IAnnotationModel;
 
   private _sharedModel: IJupyterGISDoc;
-  private _filePath: string;
-  private _contentsManager?: Contents.IManager;
   private _dirty = false;
   private _readOnly = false;
   private _isDisposed = false;

--- a/python/jupytergis_core/src/factory.ts
+++ b/python/jupytergis_core/src/factory.ts
@@ -60,7 +60,7 @@ export class JupyterGISWidgetFactory extends ABCWidgetFactory<
     }
     const { model } = context;
     if (this._contentsManager) {
-      model.setContentsManager(this._contentsManager, context.path);
+      // model.setContentsManager(this._contentsManager, context.path);
     }
 
     const content = new JupyterGISPanel({


### PR DESCRIPTION
* Fix typo in ReadTheDocs PR link automation

* Account for trailing slash in {docs-pr-index-url} slug

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--3.org.readthedocs.build/en/3/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->