### PR TITLE
Fix pr badge

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](docs-pr-index-url/lite)
+            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite)

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite)
+            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite) docs-pr-index-url

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite) docs-pr-index-url
+            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite)

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)
+            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](docs-pr-index-url/lite)


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--6.org.readthedocs.build/en/6/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->