### PR TITLE
fix: legend and VectorTile graduated style

### DIFF
--- a/packages/base/src/features/layers/symbology/styleBuilder.ts
+++ b/packages/base/src/features/layers/symbology/styleBuilder.ts
@@ -184,12 +184,22 @@ function computeGraduatedColorStops(
     return true;
   });
 
-  if (values.length === 0) {
+  // If no feature values are in range but vmin/vmax are explicitly set (e.g.
+  // for VectorTile sources where getFeatures() is unavailable), use them as a
+  // synthetic range so stops can still be computed.
+  const effectiveValues =
+    values.length > 0
+      ? values
+      : parsedVmin !== undefined && parsedVmax !== undefined
+        ? [parsedVmin, parsedVmax]
+        : [];
+
+  if (effectiveValues.length === 0) {
     return [];
   }
 
-  const dataMin = Math.min(...values);
-  const dataMax = Math.max(...values);
+  const dataMin = Math.min(...effectiveValues);
+  const dataMax = Math.max(...effectiveValues);
   const rangeMin = parsedVmin ?? dataMin;
   const rangeMax = parsedVmax ?? dataMax;
   const rangeValues = [rangeMin, rangeMax];
@@ -197,7 +207,7 @@ function computeGraduatedColorStops(
   let stops: number[];
   switch (mode) {
     case 'quantile':
-      stops = VectorClassifications.calculateQuantileBreaks(values, nClasses);
+      stops = VectorClassifications.calculateQuantileBreaks(effectiveValues, nClasses);
       break;
     case 'equal interval':
       stops = VectorClassifications.calculateEqualIntervalBreaks(
@@ -206,7 +216,7 @@ function computeGraduatedColorStops(
       );
       break;
     case 'jenks':
-      stops = VectorClassifications.calculateJenksBreaks(values, nClasses);
+      stops = VectorClassifications.calculateJenksBreaks(effectiveValues, nClasses);
       break;
     case 'pretty':
       stops = VectorClassifications.calculatePrettyBreaks(

--- a/packages/base/src/features/layers/symbology/styleBuilder.ts
+++ b/packages/base/src/features/layers/symbology/styleBuilder.ts
@@ -207,7 +207,10 @@ function computeGraduatedColorStops(
   let stops: number[];
   switch (mode) {
     case 'quantile':
-      stops = VectorClassifications.calculateQuantileBreaks(effectiveValues, nClasses);
+      stops = VectorClassifications.calculateQuantileBreaks(
+        effectiveValues,
+        nClasses,
+      );
       break;
     case 'equal interval':
       stops = VectorClassifications.calculateEqualIntervalBreaks(
@@ -216,7 +219,10 @@ function computeGraduatedColorStops(
       );
       break;
     case 'jenks':
-      stops = VectorClassifications.calculateJenksBreaks(effectiveValues, nClasses);
+      stops = VectorClassifications.calculateJenksBreaks(
+        effectiveValues,
+        nClasses,
+      );
       break;
     case 'pretty':
       stops = VectorClassifications.calculatePrettyBreaks(

--- a/packages/base/src/workspace/panels/components/legendItem.tsx
+++ b/packages/base/src/workspace/panels/components/legendItem.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import { findExprNode } from '@/src/features/layers/symbology/colorRampUtils';
 import { useGetSymbology } from '@/src/features/layers/symbology/hooks/useGetSymbology';
+import { buildVectorFlatStyle } from '@/src/features/layers/symbology/styleBuilder';
 
 export const LegendItem: React.FC<{
   layerId: string;
@@ -73,11 +74,40 @@ export const LegendItem: React.FC<{
 
     const renderType = symbology.symbologyState?.renderType;
     const property = symbology.symbologyState?.value;
-    const fill =
-      symbology.color?.['fill-color'] ?? symbology.color?.['circle-fill-color'];
-    const stroke =
-      symbology.color?.['stroke-color'] ??
-      symbology.color?.['circle-stroke-color'];
+    const state = symbology.symbologyState;
+
+    // Compute the flat style from symbologyState. For sources where feature
+    // values are unavailable (e.g. VectorTile), use vmin/vmax as a synthetic
+    // range so graduated/categorized stops can still be derived.
+    const syntheticValues =
+      state?.vmin !== undefined && state?.vmax !== undefined
+        ? [state.vmin, state.vmax]
+        : [];
+    const computedStyle = buildVectorFlatStyle(state, syntheticValues);
+
+    const toColorString = (v: unknown): string | undefined => {
+      if (typeof v === 'string') {
+        return v;
+      }
+      if (
+        Array.isArray(v) &&
+        v.length === 4 &&
+        v.every(x => typeof x === 'number')
+      ) {
+        return `rgba(${v[0]},${v[1]},${v[2]},${v[3]})`;
+      }
+      return undefined;
+    };
+
+    // Raw OL expressions — used by graduated/categorized parsers.
+    const rawFill =
+      computedStyle?.['fill-color'] ?? computedStyle?.['circle-fill-color'];
+    const rawStroke =
+      computedStyle?.['stroke-color'] ?? computedStyle?.['circle-stroke-color'];
+
+    // Plain CSS color strings — used by single symbol rendering.
+    const fill = toColorString(rawFill);
+    const stroke = toColorString(rawStroke);
 
     // Single Symbol
     if (renderType === 'Single Symbol') {
@@ -119,7 +149,7 @@ export const LegendItem: React.FC<{
 
     // Graduated
     if (renderType === 'Graduated') {
-      const stops = parseColorStops(fill || stroke);
+      const stops = parseColorStops(rawFill ?? rawStroke);
       if (!stops.length) {
         setContent(<p style={{ fontSize: '0.8em' }}>No graduated symbology</p>);
         return;
@@ -210,7 +240,7 @@ export const LegendItem: React.FC<{
 
     // Categorized
     if (renderType === 'Categorized') {
-      const cats = parseCaseCategories(fill || stroke);
+      const cats = parseCaseCategories(rawFill ?? rawStroke);
       if (!cats.length) {
         setContent(
           <p style={{ fontSize: '0.8em' }}>No categorized symbology</p>,
@@ -259,14 +289,16 @@ export const LegendItem: React.FC<{
 
     // Heatmap
     if (renderType === 'Heatmap') {
-      const colors = Array.isArray(symbology.color) ? symbology.color : [];
+      const colors = Array.isArray(symbology.symbologyState?.gradient)
+        ? symbology.symbologyState.gradient
+        : [];
       if (!colors.length) {
         setContent(<p style={{ fontSize: '0.8em' }}>No heatmap colors</p>);
         return;
       }
 
       const gradient = `linear-gradient(to right, ${colors.join(', ')})`;
-      const reversed = symbology.symbologyState?.reverse;
+      const reversed = symbology.symbologyState?.reverseRamp;
 
       setContent(
         <div style={{ padding: 6, width: '90%' }}>


### PR DESCRIPTION
## Summary

Two fixes on top of `compute-symbology-on-runtime`:

### 1. Legend broken for all render types

`legendItem.tsx` was reading fill/stroke from `parameters.color` (the old persisted OL FlatStyle blob). Since `parameters.color` no longer exists in the new approach, fill/stroke were always `undefined`, causing all render types to show their "No … symbology" fallback.

Fix: compute the `FlatStyle` via `buildVectorFlatStyle` and parse the legend from that. Raw OL expressions (graduated interpolate, categorized case) are passed directly to the existing parsers; plain RGBA arrays are converted to CSS strings for Single Symbol.

Also fixes the Heatmap legend to read `gradient` from `symbologyState.gradient` instead of `parameters.color`, and `reverseRamp` instead of the renamed `reverse` field.

### 2. Graduated style always falls back to default for VectorTile layers

`VectorTileSource` does not expose loaded features via `getFeatures()`, so `featureValues` is always `[]` for `VectorTileLayer`. With empty feature values and no `stopsOverride`, `computeGraduatedColorStops` returned `[]` and the layer rendered with the default blue style.

Fix: when `featureValues` is empty but `vmin`/`vmax` are explicitly set, use `[vmin, vmax]` as a synthetic range so stops can still be computed. This is exact for range-based modes (equal interval, logarithmic, pretty) and a reasonable approximation for distribution-based modes (quantile, jenks).

## Test plan

- [ ] Open a VectorTile layer, set graduated symbology with `vmin`/`vmax` — colors should render correctly
- [ ] Legend shows color ramp for graduated layers
- [ ] Legend shows categories for categorized layers
- [ ] Legend shows color for single symbol layers
- [ ] Legend shows gradient for heatmap layers